### PR TITLE
[feat]: release 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",
+    "@meteora-ag/cp-amm-sdk": "^1.1.5",
+    "@meteora-ag/dynamic-bonding-curve-sdk": "^1.4.4",
     "@solana/spl-token": "^0.4.13",
     "@solana/web3.js": "^1.98.0",
     "bn.js": "^5.2.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,11 @@ export const TOKEN_VAULT_PREFIX = "token_vault";
 export const DYNAMIC_FEE_SHARING_PROGRAM_ID = new PublicKey(
   "dfsdo2UqvwfN8DuUVrMRNfQe11VaiNoKcMqLHVvDPzh"
 );
+
+export const DAMM_V2_PROGRAM_ID = new PublicKey(
+  "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG"
+);
+
+export const DBC_PROGRAM_ID = new PublicKey(
+  "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN"
+);

--- a/src/dfs.ts
+++ b/src/dfs.ts
@@ -3,6 +3,7 @@ import {
   Connection,
   PublicKey,
   Transaction,
+  TransactionInstruction,
 } from "@solana/web3.js";
 import {
   DynamicFeeSharingProgram,
@@ -12,6 +13,11 @@ import {
   FundFeeVaultParams,
   ClaimUserFeeParams,
   CreateFeeVaultPdaParams,
+  FundByDammV2ClaimFeeParams,
+  FundByDbcClaimCreatorTradingFeeParams,
+  FundByDbcClaimPartnerTradingFeeParams,
+  FundByDbcClaimCreatorSurplusParams,
+  FundByDbcClaimPartnerSurplusParams,
 } from "./types";
 import {
   createDfsProgram,
@@ -23,8 +29,16 @@ import {
   deriveTokenVaultAddress,
   wrapSOLInstruction,
   unwrapSOLInstruction,
+  deriveDammV2EventAuthorityAddress,
 } from "./helpers";
-import { NATIVE_MINT } from "@solana/spl-token";
+import { getAssociatedTokenAddressSync, NATIVE_MINT } from "@solana/spl-token";
+import { CpAmm, derivePoolAuthority } from "@meteora-ag/cp-amm-sdk";
+import { DAMM_V2_PROGRAM_ID, DBC_PROGRAM_ID } from "./constants";
+import {
+  deriveDbcEventAuthority,
+  deriveDbcPoolAuthority,
+  DynamicBondingCurveClient,
+} from "@meteora-ag/dynamic-bonding-curve-sdk";
 
 export class DynamicFeeSharingClient {
   program: DynamicFeeSharingProgram;
@@ -53,13 +67,11 @@ export class DynamicFeeSharingClient {
    * @param createFeeVaultParams - The parameters for creating a fee vault
    * @returns The transaction to create a fee vault
    */
-  async createFeeVault(
-    createFeeVaultParams: CreateFeeVaultParams
-  ): Promise<Transaction> {
+  async createFeeVault(params: CreateFeeVaultParams): Promise<Transaction> {
     const { feeVault, tokenMint, tokenProgram, owner, payer, userShare } =
-      createFeeVaultParams;
+      params;
 
-    const params: InitializeFeeVaultParameters = {
+    const initializeFeeVaultParams: InitializeFeeVaultParameters = {
       padding: [],
       users: userShare.map((share) => ({
         address: share.address,
@@ -70,7 +82,7 @@ export class DynamicFeeSharingClient {
     const tokenVault = deriveTokenVaultAddress(feeVault);
 
     return this.program.methods
-      .initializeFeeVault(params)
+      .initializeFeeVault(initializeFeeVaultParams)
       .accountsPartial({
         feeVault,
         feeVaultAuthority: this.feeVaultAuthority,
@@ -89,12 +101,11 @@ export class DynamicFeeSharingClient {
    * @returns The transaction to create a fee vault PDA
    */
   async createFeeVaultPda(
-    createFeeVaultPdaParams: CreateFeeVaultPdaParams
+    params: CreateFeeVaultPdaParams
   ): Promise<Transaction> {
-    const { base, tokenMint, tokenProgram, owner, payer, userShare } =
-      createFeeVaultPdaParams;
+    const { base, tokenMint, tokenProgram, owner, payer, userShare } = params;
 
-    const params: InitializeFeeVaultParameters = {
+    const initializeFeeVaultParams: InitializeFeeVaultParameters = {
       padding: [],
       users: userShare.map((share) => ({
         address: share.address,
@@ -106,7 +117,7 @@ export class DynamicFeeSharingClient {
     const tokenVault = deriveTokenVaultAddress(feeVault);
 
     return this.program.methods
-      .initializeFeeVaultPda(params)
+      .initializeFeeVaultPda(initializeFeeVaultParams)
       .accountsPartial({
         feeVault,
         base,
@@ -125,10 +136,8 @@ export class DynamicFeeSharingClient {
    * @param fundFeeVaultParams - The parameters for funding a fee vault
    * @returns The transaction to fund a fee vault
    */
-  async fundFeeVault(
-    fundFeeVaultParams: FundFeeVaultParams
-  ): Promise<Transaction> {
-    const { fundAmount, feeVault, funder } = fundFeeVaultParams;
+  async fundFeeVault(params: FundFeeVaultParams): Promise<Transaction> {
+    const { fundAmount, feeVault, funder } = params;
 
     const feeVaultState = await this.getFeeVault(feeVault);
     const tokenVault = feeVaultState.tokenVault;
@@ -140,7 +149,7 @@ export class DynamicFeeSharingClient {
 
     const { ataPubkey: fundTokenVault, ix: preInstruction } =
       await getOrCreateATAInstruction(
-        this.program.provider.connection,
+        this.connection,
         tokenMint,
         funder,
         funder,
@@ -177,14 +186,275 @@ export class DynamicFeeSharingClient {
   }
 
   /**
+   * Fund a fee vault by claiming a fee from a damm v2 pool
+   * @param params - The parameters for funding a fee vault by claiming a fee from a damm v2 pool
+   * @returns The transaction to fund a fee vault by claiming a fee from a damm v2 pool
+   */
+  async fundByDammV2ClaimFee(
+    params: FundByDammV2ClaimFeeParams
+  ): Promise<Transaction> {
+    const {
+      owner,
+      feeVault,
+      tokenVault,
+      dammV2Pool,
+      position,
+      positionNftAccount,
+    } = params;
+
+    const cpAmmClient = new CpAmm(this.connection);
+
+    const dammV2PoolState = await cpAmmClient.fetchPoolState(dammV2Pool);
+    if (!dammV2PoolState) {
+      throw new Error("InvalidDammV2Pool: DammV2 pool not found");
+    }
+
+    const preInstructions: TransactionInstruction[] = [];
+    const { ataPubkey: tokenAAccount, ix: createTokenAAccountIx } =
+      await getOrCreateATAInstruction(
+        this.connection,
+        dammV2PoolState.tokenAMint,
+        owner,
+        owner,
+        true,
+        getTokenProgram(dammV2PoolState.tokenAFlag)
+      );
+    createTokenAAccountIx && preInstructions.push(createTokenAAccountIx);
+
+    return this.program.methods
+      .fundingByClaimDammv2Fee()
+      .accountsPartial({
+        feeVault,
+        pool: dammV2Pool,
+        position,
+        positionNftAccount,
+        tokenAAccount,
+        tokenBAccount: tokenVault,
+        tokenAVault: dammV2PoolState.tokenAVault,
+        tokenBVault: dammV2PoolState.tokenBVault,
+        tokenAMint: dammV2PoolState.tokenAMint,
+        tokenBMint: dammV2PoolState.tokenBMint,
+        tokenAProgram: getTokenProgram(dammV2PoolState.tokenAFlag),
+        tokenBProgram: getTokenProgram(dammV2PoolState.tokenBFlag),
+        dammv2EventAuthority: deriveDammV2EventAuthorityAddress(),
+        dammv2PoolAuthority: derivePoolAuthority(),
+        dammv2Program: DAMM_V2_PROGRAM_ID,
+      })
+      .preInstructions(preInstructions)
+      .transaction();
+  }
+
+  /**
+   * Fund a fee vault by claiming a fee from a dbc creator surplus
+   * @param params - The parameters for funding a fee vault by claiming a fee from a dbc creator surplus
+   * @returns The transaction to fund a fee vault by claiming a fee from a dbc creator surplus
+   */
+  async fundByDbcClaimCreatorSurplus(
+    params: FundByDbcClaimCreatorSurplusParams
+  ) {
+    const { feeVault, tokenVault, dbcConfig, dbcPool } = params;
+
+    const dbcClient = new DynamicBondingCurveClient(
+      this.connection,
+      this.commitment
+    );
+
+    const virtualPoolState = await dbcClient.state.getPool(dbcPool);
+    if (!virtualPoolState) {
+      throw new Error("InvalidDbcPool: Dbc pool not found");
+    }
+
+    const configState = await dbcClient.state.getPoolConfig(dbcConfig);
+    if (!configState) {
+      throw new Error("InvalidDbcConfig: Dbc config not found");
+    }
+
+    return this.program.methods
+      .fundingByClaimDbcCreatorSurplus()
+      .accountsPartial({
+        feeVault,
+        config: dbcConfig,
+        pool: dbcPool,
+        tokenQuoteAccount: tokenVault,
+        quoteVault: virtualPoolState.quoteVault,
+        quoteMint: configState.quoteMint,
+        tokenBaseProgram: getTokenProgram(configState.tokenType),
+        tokenQuoteProgram: getTokenProgram(configState.quoteTokenFlag),
+        dbcEventAuthority: deriveDbcEventAuthority(),
+        dbcPoolAuthority: deriveDbcPoolAuthority(),
+        dbcProgram: DBC_PROGRAM_ID,
+      })
+      .transaction();
+  }
+
+  /**
+   * Fund a fee vault by claiming a fee from a dbc partner surplus
+   * @param params - The parameters for funding a fee vault by claiming a fee from a dbc partner surplus
+   * @returns The transaction to fund a fee vault by claiming a fee from a dbc partner surplus
+   */
+  async fundByDbcClaimPartnerSurplus(
+    params: FundByDbcClaimPartnerSurplusParams
+  ) {
+    const { feeVault, tokenVault, dbcConfig, dbcPool } = params;
+
+    const dbcClient = new DynamicBondingCurveClient(
+      this.connection,
+      this.commitment
+    );
+
+    const virtualPoolState = await dbcClient.state.getPool(dbcPool);
+    if (!virtualPoolState) {
+      throw new Error("InvalidDbcPool: Dbc pool not found");
+    }
+
+    const configState = await dbcClient.state.getPoolConfig(dbcConfig);
+    if (!configState) {
+      throw new Error("InvalidDbcConfig: Dbc config not found");
+    }
+
+    return this.program.methods
+      .fundingByClaimDbcPartnerSurplus()
+      .accountsPartial({
+        feeVault,
+        config: dbcConfig,
+        pool: dbcPool,
+        tokenQuoteAccount: tokenVault,
+        quoteVault: virtualPoolState.quoteVault,
+        quoteMint: configState.quoteMint,
+        tokenBaseProgram: getTokenProgram(configState.tokenType),
+        tokenQuoteProgram: getTokenProgram(configState.quoteTokenFlag),
+        dbcEventAuthority: deriveDbcEventAuthority(),
+        dbcPoolAuthority: deriveDbcPoolAuthority(),
+        dbcProgram: DBC_PROGRAM_ID,
+      })
+      .transaction();
+  }
+
+  /**
+   * Fund a fee vault by claiming a fee from a dbc creator trading fee
+   * @param params - The parameters for funding a fee vault by claiming a fee from a dbc creator trading fee
+   * @returns The transaction to fund a fee vault by claiming a fee from a dbc creator trading fee
+   */
+  async fundByDbcClaimCreatorTradingFee(
+    params: FundByDbcClaimCreatorTradingFeeParams
+  ): Promise<Transaction> {
+    const { creator, feeVault, tokenVault, dbcConfig, dbcPool } = params;
+
+    const dbcClient = new DynamicBondingCurveClient(
+      this.connection,
+      this.commitment
+    );
+
+    const virtualPoolState = await dbcClient.state.getPool(dbcPool);
+    if (!virtualPoolState) {
+      throw new Error("InvalidDbcPool: Dbc pool not found");
+    }
+
+    const configState = await dbcClient.state.getPoolConfig(dbcConfig);
+    if (!configState) {
+      throw new Error("InvalidDbcConfig: Dbc config not found");
+    }
+
+    const preInstructions: TransactionInstruction[] = [];
+    const { ataPubkey: tokenAAccount, ix: createTokenAAccountIx } =
+      await getOrCreateATAInstruction(
+        this.connection,
+        virtualPoolState.baseMint,
+        creator,
+        creator,
+        true,
+        getTokenProgram(configState.tokenType)
+      );
+    createTokenAAccountIx && preInstructions.push(createTokenAAccountIx);
+
+    return this.program.methods
+      .fundingByClaimDbcCreatorTradingFee()
+      .accountsPartial({
+        feeVault,
+        config: dbcConfig,
+        pool: dbcPool,
+        tokenAAccount,
+        tokenBAccount: tokenVault,
+        baseVault: virtualPoolState.baseVault,
+        quoteVault: virtualPoolState.quoteVault,
+        baseMint: virtualPoolState.baseMint,
+        quoteMint: configState.quoteMint,
+        tokenBaseProgram: getTokenProgram(configState.tokenType),
+        tokenQuoteProgram: getTokenProgram(configState.quoteTokenFlag),
+        dbcEventAuthority: deriveDbcEventAuthority(),
+        dbcPoolAuthority: deriveDbcPoolAuthority(),
+        dbcProgram: DBC_PROGRAM_ID,
+      })
+      .preInstructions(preInstructions)
+      .transaction();
+  }
+
+  /**
+   * Fund a fee vault by claiming a fee from a dbc partner trading fee
+   * @param params - The parameters for funding a fee vault by claiming a fee from a dbc partner trading fee
+   * @returns The transaction to fund a fee vault by claiming a fee from a dbc partner trading fee
+   */
+  async fundByDbcClaimPartnerTradingFee(
+    params: FundByDbcClaimPartnerTradingFeeParams
+  ) {
+    const { feeClaimer, feeVault, tokenVault, dbcConfig, dbcPool } = params;
+
+    const dbcClient = new DynamicBondingCurveClient(
+      this.connection,
+      this.commitment
+    );
+
+    const virtualPoolState = await dbcClient.state.getPool(dbcPool);
+    if (!virtualPoolState) {
+      throw new Error("InvalidDbcPool: Dbc pool not found");
+    }
+
+    const configState = await dbcClient.state.getPoolConfig(dbcConfig);
+    if (!configState) {
+      throw new Error("InvalidDbcConfig: Dbc config not found");
+    }
+
+    const preInstructions: TransactionInstruction[] = [];
+    const { ataPubkey: tokenAAccount, ix: createTokenAAccountIx } =
+      await getOrCreateATAInstruction(
+        this.connection,
+        virtualPoolState.baseMint,
+        feeClaimer,
+        feeClaimer,
+        true,
+        getTokenProgram(configState.tokenType)
+      );
+    createTokenAAccountIx && preInstructions.push(createTokenAAccountIx);
+
+    return this.program.methods
+      .fundingByClaimDbcPartnerTradingFee()
+      .accountsPartial({
+        feeVault,
+        config: dbcConfig,
+        pool: dbcPool,
+        tokenAAccount,
+        tokenBAccount: tokenVault,
+        baseVault: virtualPoolState.baseVault,
+        quoteVault: virtualPoolState.quoteVault,
+        baseMint: virtualPoolState.baseMint,
+        quoteMint: configState.quoteMint,
+        tokenBaseProgram: getTokenProgram(configState.tokenType),
+        tokenQuoteProgram: getTokenProgram(configState.quoteTokenFlag),
+        dbcEventAuthority: deriveDbcEventAuthority(),
+        dbcPoolAuthority: deriveDbcPoolAuthority(),
+        dbcProgram: DBC_PROGRAM_ID,
+      })
+      .preInstructions(preInstructions)
+      .transaction();
+  }
+
+  /**
    * Claim user fee
    * @param claimUserFeeParams - The parameters for claiming user fee
    * @returns The transaction to claim user fee
    */
-  async claimUserFee(
-    claimUserFeeParams: ClaimUserFeeParams
-  ): Promise<Transaction> {
-    const { feeVault, user, payer } = claimUserFeeParams;
+  async claimUserFee(params: ClaimUserFeeParams): Promise<Transaction> {
+    const { feeVault, user, payer } = params;
 
     const feeVaultState = await this.getFeeVault(feeVault);
     const tokenVault = feeVaultState.tokenVault;
@@ -206,7 +476,7 @@ export class DynamicFeeSharingClient {
 
     const { ataPubkey: userTokenVault, ix: preInstruction } =
       await getOrCreateATAInstruction(
-        this.program.provider.connection,
+        this.connection,
         tokenMint,
         user,
         payer,

--- a/src/helpers/accounts.ts
+++ b/src/helpers/accounts.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import {
+  DAMM_V2_PROGRAM_ID,
   DYNAMIC_FEE_SHARING_PROGRAM_ID,
   FEE_VAULT_AUTHORITY_PREFIX,
   FEE_VAULT_PREFIX,
@@ -27,5 +28,12 @@ export function deriveFeeVaultPdaAddress(
   return PublicKey.findProgramAddressSync(
     [Buffer.from(FEE_VAULT_PREFIX), base.toBuffer(), tokenMint.toBuffer()],
     DYNAMIC_FEE_SHARING_PROGRAM_ID
+  )[0];
+}
+
+export function deriveDammV2EventAuthorityAddress(): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("__event_authority")],
+    DAMM_V2_PROGRAM_ID
   )[0];
 }

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,6 +1,8 @@
 import {
+  AuthorityType,
   createAssociatedTokenAccountIdempotentInstruction,
   createCloseAccountInstruction,
+  createSetAuthorityInstruction,
   getAccount,
   getAssociatedTokenAddressSync,
   NATIVE_MINT,
@@ -13,6 +15,7 @@ import {
   Connection,
   PublicKey,
   SystemProgram,
+  Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
 import { TokenType } from "../types";
@@ -107,4 +110,22 @@ export function unwrapSOLInstruction(
     return closedWrappedSolInstruction;
   }
   return null;
+}
+
+export function setTokenAccountOwnerTx(
+  positionNftAccount: PublicKey,
+  currentOwnerPubkey: PublicKey,
+  feeVault: PublicKey,
+  tokenProgramId: PublicKey
+): Transaction {
+  const setAuthorityIx = createSetAuthorityInstruction(
+    positionNftAccount,
+    currentOwnerPubkey,
+    AuthorityType.AccountOwner,
+    feeVault,
+    [],
+    tokenProgramId
+  );
+
+  return new Transaction().add(setAuthorityIx);
 }

--- a/src/idl/idl.json
+++ b/src/idl/idl.json
@@ -2,7 +2,7 @@
     "address": "dfsdo2UqvwfN8DuUVrMRNfQe11VaiNoKcMqLHVvDPzh",
     "metadata": {
         "name": "dynamic_fee_sharing",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "spec": "0.1.0",
         "description": "Created with Anchor"
     },
@@ -26,34 +26,7 @@
                 },
                 {
                     "name": "fee_vault_authority",
-                    "pda": {
-                        "seeds": [
-                            {
-                                "kind": "const",
-                                "value": [
-                                    102,
-                                    101,
-                                    101,
-                                    95,
-                                    118,
-                                    97,
-                                    117,
-                                    108,
-                                    116,
-                                    95,
-                                    97,
-                                    117,
-                                    116,
-                                    104,
-                                    111,
-                                    114,
-                                    105,
-                                    116,
-                                    121
-                                ]
-                            }
-                        ]
-                    }
+                    "address": "EYqHRdtepv1KKUkPAYMBYpSfiGfNd8sa55ZtswodTfBS"
                 },
                 {
                     "name": "token_vault",
@@ -199,6 +172,514 @@
                     "type": "u64"
                 }
             ]
+        },
+        {
+            "name": "funding_by_claim_dammv2_fee",
+            "discriminator": [
+                41,
+                114,
+                86,
+                74,
+                99,
+                80,
+                149,
+                203
+            ],
+            "accounts": [
+                {
+                    "name": "fee_vault",
+                    "writable": true
+                },
+                {
+                    "name": "pool"
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_nft_account",
+                    "docs": [
+                        "The token account for nft"
+                    ]
+                },
+                {
+                    "name": "token_a_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_b_account",
+                    "docs": [
+                        "The user token b account"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "token_a_vault",
+                    "docs": [
+                        "The vault token account for input token"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "token_b_vault",
+                    "docs": [
+                        "The vault token account for output token"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "token_a_mint",
+                    "docs": [
+                        "The mint of token a"
+                    ]
+                },
+                {
+                    "name": "token_b_mint",
+                    "docs": [
+                        "The mint of token b"
+                    ]
+                },
+                {
+                    "name": "token_a_program"
+                },
+                {
+                    "name": "token_b_program"
+                },
+                {
+                    "name": "dammv2_pool_authority"
+                },
+                {
+                    "name": "dammv2_program",
+                    "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG"
+                },
+                {
+                    "name": "dammv2_event_authority"
+                },
+                {
+                    "name": "event_authority",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    95,
+                                    95,
+                                    101,
+                                    118,
+                                    101,
+                                    110,
+                                    116,
+                                    95,
+                                    97,
+                                    117,
+                                    116,
+                                    104,
+                                    111,
+                                    114,
+                                    105,
+                                    116,
+                                    121
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "program"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "funding_by_claim_dbc_creator_surplus",
+            "discriminator": [
+                236,
+                206,
+                26,
+                241,
+                85,
+                228,
+                45,
+                93
+            ],
+            "accounts": [
+                {
+                    "name": "fee_vault",
+                    "writable": true
+                },
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "pool",
+                    "docs": [
+                        "The dbc virtual pool"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "token_quote_account",
+                    "docs": [
+                        "The treasury token b account"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "quote_vault",
+                    "writable": true
+                },
+                {
+                    "name": "quote_mint"
+                },
+                {
+                    "name": "token_base_program"
+                },
+                {
+                    "name": "token_quote_program"
+                },
+                {
+                    "name": "dbc_pool_authority"
+                },
+                {
+                    "name": "dbc_program",
+                    "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN"
+                },
+                {
+                    "name": "dbc_event_authority"
+                },
+                {
+                    "name": "event_authority",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    95,
+                                    95,
+                                    101,
+                                    118,
+                                    101,
+                                    110,
+                                    116,
+                                    95,
+                                    97,
+                                    117,
+                                    116,
+                                    104,
+                                    111,
+                                    114,
+                                    105,
+                                    116,
+                                    121
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "program"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "funding_by_claim_dbc_creator_trading_fee",
+            "discriminator": [
+                255,
+                219,
+                222,
+                197,
+                46,
+                146,
+                167,
+                4
+            ],
+            "accounts": [
+                {
+                    "name": "fee_vault",
+                    "writable": true
+                },
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "pool",
+                    "writable": true
+                },
+                {
+                    "name": "token_a_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_b_account",
+                    "docs": [
+                        "The token b account"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "base_vault",
+                    "writable": true
+                },
+                {
+                    "name": "quote_vault",
+                    "writable": true
+                },
+                {
+                    "name": "base_mint"
+                },
+                {
+                    "name": "quote_mint",
+                    "relations": [
+                        "config"
+                    ]
+                },
+                {
+                    "name": "token_base_program"
+                },
+                {
+                    "name": "token_quote_program"
+                },
+                {
+                    "name": "dbc_pool_authority"
+                },
+                {
+                    "name": "dbc_program",
+                    "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN"
+                },
+                {
+                    "name": "dbc_event_authority"
+                },
+                {
+                    "name": "event_authority",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    95,
+                                    95,
+                                    101,
+                                    118,
+                                    101,
+                                    110,
+                                    116,
+                                    95,
+                                    97,
+                                    117,
+                                    116,
+                                    104,
+                                    111,
+                                    114,
+                                    105,
+                                    116,
+                                    121
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "program"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "funding_by_claim_dbc_partner_surplus",
+            "discriminator": [
+                146,
+                67,
+                241,
+                237,
+                23,
+                164,
+                213,
+                113
+            ],
+            "accounts": [
+                {
+                    "name": "fee_vault",
+                    "writable": true
+                },
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "pool",
+                    "docs": [
+                        "The dbc virtual pool"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "token_quote_account",
+                    "docs": [
+                        "The token b account"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "quote_vault",
+                    "writable": true
+                },
+                {
+                    "name": "quote_mint"
+                },
+                {
+                    "name": "token_base_program"
+                },
+                {
+                    "name": "token_quote_program"
+                },
+                {
+                    "name": "dbc_pool_authority"
+                },
+                {
+                    "name": "dbc_program",
+                    "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN"
+                },
+                {
+                    "name": "dbc_event_authority"
+                },
+                {
+                    "name": "event_authority",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    95,
+                                    95,
+                                    101,
+                                    118,
+                                    101,
+                                    110,
+                                    116,
+                                    95,
+                                    97,
+                                    117,
+                                    116,
+                                    104,
+                                    111,
+                                    114,
+                                    105,
+                                    116,
+                                    121
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "program"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "funding_by_claim_dbc_partner_trading_fee",
+            "discriminator": [
+                0,
+                156,
+                54,
+                230,
+                218,
+                238,
+                81,
+                47
+            ],
+            "accounts": [
+                {
+                    "name": "fee_vault",
+                    "writable": true
+                },
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "pool",
+                    "writable": true
+                },
+                {
+                    "name": "token_a_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_b_account",
+                    "docs": [
+                        "The treasury token b account"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "base_vault",
+                    "writable": true
+                },
+                {
+                    "name": "quote_vault",
+                    "writable": true
+                },
+                {
+                    "name": "base_mint"
+                },
+                {
+                    "name": "quote_mint",
+                    "relations": [
+                        "config"
+                    ]
+                },
+                {
+                    "name": "token_base_program"
+                },
+                {
+                    "name": "token_quote_program"
+                },
+                {
+                    "name": "dbc_pool_authority"
+                },
+                {
+                    "name": "dbc_program",
+                    "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN"
+                },
+                {
+                    "name": "dbc_event_authority"
+                },
+                {
+                    "name": "event_authority",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    95,
+                                    95,
+                                    101,
+                                    118,
+                                    101,
+                                    110,
+                                    116,
+                                    95,
+                                    97,
+                                    117,
+                                    116,
+                                    104,
+                                    111,
+                                    114,
+                                    105,
+                                    116,
+                                    121
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "program"
+                }
+            ],
+            "args": []
         },
         {
             "name": "initialize_fee_vault",
@@ -521,6 +1002,45 @@
                 157,
                 132
             ]
+        },
+        {
+            "name": "Pool",
+            "discriminator": [
+                241,
+                154,
+                109,
+                4,
+                17,
+                177,
+                109,
+                188
+            ]
+        },
+        {
+            "name": "PoolConfig",
+            "discriminator": [
+                26,
+                108,
+                14,
+                123,
+                116,
+                230,
+                129,
+                43
+            ]
+        },
+        {
+            "name": "VirtualPool",
+            "discriminator": [
+                213,
+                224,
+                5,
+                209,
+                98,
+                69,
+                119,
+                92
+            ]
         }
     ],
     "events": [
@@ -599,9 +1119,241 @@
             "code": 6006,
             "name": "ExceededUser",
             "msg": "Exceeded number of users allowed"
+        },
+        {
+            "code": 6007,
+            "name": "InvalidFeeVault",
+            "msg": "Invalid fee vault"
+        },
+        {
+            "code": 6008,
+            "name": "InvalidDammv2Pool",
+            "msg": "Invalid dammv2 pool"
+        },
+        {
+            "code": 6009,
+            "name": "InvalidDbcPool",
+            "msg": "Invalid dammv2 pool"
         }
     ],
     "types": [
+        {
+            "name": "BaseFeeConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "cliff_fee_numerator",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "second_factor",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "third_factor",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "first_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "base_fee_mode",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                5
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "BaseFeeStruct",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "cliff_fee_numerator",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_scheduler_mode",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                5
+                            ]
+                        }
+                    },
+                    {
+                        "name": "number_of_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "period_frequency",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "padding_1",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicFeeConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "padding",
+                        "type": {
+                            "array": [
+                                "u8",
+                                7
+                            ]
+                        }
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "variable_fee_control",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "bin_step",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "padding2",
+                        "type": {
+                            "array": [
+                                "u8",
+                                8
+                            ]
+                        }
+                    },
+                    {
+                        "name": "bin_step_u128",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicFeeStruct",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "padding",
+                        "type": {
+                            "array": [
+                                "u8",
+                                7
+                            ]
+                        }
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "variable_fee_control",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "bin_step",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "last_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "bin_step_u128",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price_reference",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
         {
             "name": "EvtClaimFee",
             "type": {
@@ -632,6 +1384,14 @@
                 "kind": "struct",
                 "fields": [
                     {
+                        "name": "funding_type",
+                        "type": {
+                            "defined": {
+                                "name": "FundingType"
+                            }
+                        }
+                    },
+                    {
                         "name": "fee_vault",
                         "type": "pubkey"
                     },
@@ -640,11 +1400,7 @@
                         "type": "pubkey"
                     },
                     {
-                        "name": "excluded_transfer_fee_amount",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "max_amount",
+                        "name": "funded_amount",
                         "type": "u64"
                     },
                     {
@@ -712,11 +1468,19 @@
                         "type": "u8"
                     },
                     {
+                        "name": "fee_vault_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "fee_vault_bump",
+                        "type": "u8"
+                    },
+                    {
                         "name": "padding_0",
                         "type": {
                             "array": [
                                 "u8",
-                                15
+                                13
                             ]
                         }
                     },
@@ -742,11 +1506,15 @@
                         "type": "u128"
                     },
                     {
+                        "name": "base",
+                        "type": "pubkey"
+                    },
+                    {
                         "name": "padding",
                         "type": {
                             "array": [
                                 "u128",
-                                6
+                                4
                             ]
                         }
                     },
@@ -762,6 +1530,35 @@
                                 5
                             ]
                         }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FundingType",
+            "repr": {
+                "kind": "rust"
+            },
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Direct"
+                    },
+                    {
+                        "name": "ClaimDammV2"
+                    },
+                    {
+                        "name": "ClaimDbcPartnerTradingFee"
+                    },
+                    {
+                        "name": "ClaimDbcCreatorTradingFee"
+                    },
+                    {
+                        "name": "ClaimDbcPartnerSurplus"
+                    },
+                    {
+                        "name": "ClaimDbcCreatorSurplus"
                     }
                 ]
             }
@@ -789,6 +1586,619 @@
                                 }
                             }
                         }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDistributionConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockedVestingConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "amount_per_period",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "cliff_duration_from_migration_time",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "frequency",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "number_of_period",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "cliff_unlock_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "_padding",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Pool",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "pool_fees",
+                        "type": {
+                            "defined": {
+                                "name": "PoolFeesStruct"
+                            }
+                        }
+                    },
+                    {
+                        "name": "token_a_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_b_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_a_vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_b_vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whitelisted_vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "partner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "_padding",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "protocol_a_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_b_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "partner_a_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "partner_b_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "sqrt_min_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_max_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "activation_point",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "activation_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "pool_status",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "token_a_flag",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "token_b_flag",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "collect_fee_mode",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "pool_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "_padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_a_per_liquidity",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_b_per_liquidity",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "permanent_lock_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "metrics",
+                        "type": {
+                            "defined": {
+                                "name": "damm_v2::damm_v2::types::PoolMetrics"
+                            }
+                        }
+                    },
+                    {
+                        "name": "creator",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "_padding_1",
+                        "type": {
+                            "array": [
+                                "u64",
+                                6
+                            ]
+                        }
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "RewardInfo"
+                                    }
+                                },
+                                2
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "quote_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_claimer",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "leftover_receiver",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "pool_fees",
+                        "type": {
+                            "defined": {
+                                "name": "PoolFeesConfig"
+                            }
+                        }
+                    },
+                    {
+                        "name": "collect_fee_mode",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migration_option",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "activation_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "token_decimal",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "version",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "token_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "quote_token_flag",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "partner_locked_lp_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "partner_lp_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "creator_locked_lp_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "creator_lp_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migration_fee_option",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "fixed_token_supply_flag",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "creator_trading_fee_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "token_update_authority",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migration_fee_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "creator_migration_fee_percentage",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "_padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                7
+                            ]
+                        }
+                    },
+                    {
+                        "name": "swap_base_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "migration_quote_threshold",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "migration_base_threshold",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "migration_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "locked_vesting_config",
+                        "type": {
+                            "defined": {
+                                "name": "LockedVestingConfig"
+                            }
+                        }
+                    },
+                    {
+                        "name": "pre_migration_token_supply",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "post_migration_token_supply",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "migrated_collect_fee_mode",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migrated_dynamic_fee",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migrated_pool_fee_bps",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "_padding_1",
+                        "type": {
+                            "array": [
+                                "u8",
+                                12
+                            ]
+                        }
+                    },
+                    {
+                        "name": "_padding_2",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_start_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "curve",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "LiquidityDistributionConfig"
+                                    }
+                                },
+                                20
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolFeesConfig",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "base_fee",
+                        "type": {
+                            "defined": {
+                                "name": "BaseFeeConfig"
+                            }
+                        }
+                    },
+                    {
+                        "name": "dynamic_fee",
+                        "type": {
+                            "defined": {
+                                "name": "DynamicFeeConfig"
+                            }
+                        }
+                    },
+                    {
+                        "name": "padding_0",
+                        "type": {
+                            "array": [
+                                "u64",
+                                5
+                            ]
+                        }
+                    },
+                    {
+                        "name": "padding_1",
+                        "type": {
+                            "array": [
+                                "u8",
+                                6
+                            ]
+                        }
+                    },
+                    {
+                        "name": "protocol_fee_percent",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "referral_fee_percent",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolFeesStruct",
+            "docs": [
+                "Information regarding fee charges",
+                "trading_fee = amount * trade_fee_numerator / denominator",
+                "protocol_fee = trading_fee * protocol_fee_percentage / 100",
+                "referral_fee = protocol_fee * referral_percentage / 100",
+                "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+            ],
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "base_fee",
+                        "type": {
+                            "defined": {
+                                "name": "BaseFeeStruct"
+                            }
+                        }
+                    },
+                    {
+                        "name": "protocol_fee_percent",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "partner_fee_percent",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "referral_fee_percent",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                5
+                            ]
+                        }
+                    },
+                    {
+                        "name": "dynamic_fee",
+                        "type": {
+                            "defined": {
+                                "name": "DynamicFeeStruct"
+                            }
+                        }
+                    },
+                    {
+                        "name": "padding_1",
+                        "type": {
+                            "array": [
+                                "u64",
+                                2
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards"
+            ],
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "reward_token_flag",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "_padding_0",
+                        "type": {
+                            "array": [
+                                "u8",
+                                6
+                            ]
+                        }
+                    },
+                    {
+                        "name": "_padding_1",
+                        "type": {
+                            "array": [
+                                "u8",
+                                8
+                            ]
+                        }
+                    },
+                    {
+                        "name": "mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "funder",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_duration",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_duration_end",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_rate",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_per_token_stored",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "last_update_time",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "cumulative_seconds_with_empty_liquidity_reward",
+                        "type": "u64"
                     }
                 ]
             }
@@ -851,6 +2261,248 @@
                     {
                         "name": "share",
                         "type": "u32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "VirtualPool",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "volatility_tracker",
+                        "type": {
+                            "defined": {
+                                "name": "VolatilityTracker"
+                            }
+                        }
+                    },
+                    {
+                        "name": "config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "creator",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "base_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "base_vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "quote_vault",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "base_reserve",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "quote_reserve",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_base_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_quote_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "partner_base_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "partner_quote_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "activation_point",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "pool_type",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "is_migrated",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "is_partner_withdraw_surplus",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "is_protocol_withdraw_surplus",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migration_progress",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "is_withdraw_leftover",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "is_creator_withdraw_surplus",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "migration_fee_withdraw_status",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metrics",
+                        "type": {
+                            "defined": {
+                                "name": "dynamic_bonding_curve::dynamic_bonding_curve::types::PoolMetrics"
+                            }
+                        }
+                    },
+                    {
+                        "name": "finish_curve_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "creator_base_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "creator_quote_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "_padding_1",
+                        "type": {
+                            "array": [
+                                "u64",
+                                7
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "VolatilityTracker",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "padding",
+                        "type": {
+                            "array": [
+                                "u8",
+                                8
+                            ]
+                        }
+                    },
+                    {
+                        "name": "sqrt_price_reference",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "damm_v2::damm_v2::types::PoolMetrics",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "total_lp_a_fee",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "total_lp_b_fee",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "total_protocol_a_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_protocol_b_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_partner_a_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_partner_b_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_position",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "padding",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "dynamic_bonding_curve::dynamic_bonding_curve::types::PoolMetrics",
+            "serialization": "bytemuck",
+            "repr": {
+                "kind": "c"
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "total_protocol_base_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_protocol_quote_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_trading_base_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "total_trading_quote_fee",
+                        "type": "u64"
                     }
                 ]
             }

--- a/src/idl/idl.ts
+++ b/src/idl/idl.ts
@@ -8,7 +8,7 @@ export type DynamicFeeSharing = {
   address: "dfsdo2UqvwfN8DuUVrMRNfQe11VaiNoKcMqLHVvDPzh";
   metadata: {
     name: "dynamicFeeSharing";
-    version: "0.1.0";
+    version: "0.1.1";
     spec: "0.1.0";
     description: "Created with Anchor";
   };
@@ -23,34 +23,7 @@ export type DynamicFeeSharing = {
         },
         {
           name: "feeVaultAuthority";
-          pda: {
-            seeds: [
-              {
-                kind: "const";
-                value: [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ];
-              }
-            ];
-          };
+          address: "EYqHRdtepv1KKUkPAYMBYpSfiGfNd8sa55ZtswodTfBS";
         },
         {
           name: "tokenVault";
@@ -179,6 +152,441 @@ export type DynamicFeeSharing = {
           type: "u64";
         }
       ];
+    },
+    {
+      name: "fundingByClaimDammv2Fee";
+      discriminator: [41, 114, 86, 74, 99, 80, 149, 203];
+      accounts: [
+        {
+          name: "feeVault";
+          writable: true;
+        },
+        {
+          name: "pool";
+        },
+        {
+          name: "position";
+          writable: true;
+        },
+        {
+          name: "positionNftAccount";
+          docs: ["The token account for nft"];
+        },
+        {
+          name: "tokenAAccount";
+          writable: true;
+        },
+        {
+          name: "tokenBAccount";
+          docs: ["The user token b account"];
+          writable: true;
+        },
+        {
+          name: "tokenAVault";
+          docs: ["The vault token account for input token"];
+          writable: true;
+        },
+        {
+          name: "tokenBVault";
+          docs: ["The vault token account for output token"];
+          writable: true;
+        },
+        {
+          name: "tokenAMint";
+          docs: ["The mint of token a"];
+        },
+        {
+          name: "tokenBMint";
+          docs: ["The mint of token b"];
+        },
+        {
+          name: "tokenAProgram";
+        },
+        {
+          name: "tokenBProgram";
+        },
+        {
+          name: "dammv2PoolAuthority";
+        },
+        {
+          name: "dammv2Program";
+          address: "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
+        },
+        {
+          name: "dammv2EventAuthority";
+        },
+        {
+          name: "eventAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ];
+              }
+            ];
+          };
+        },
+        {
+          name: "program";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "fundingByClaimDbcCreatorSurplus";
+      discriminator: [236, 206, 26, 241, 85, 228, 45, 93];
+      accounts: [
+        {
+          name: "feeVault";
+          writable: true;
+        },
+        {
+          name: "config";
+        },
+        {
+          name: "pool";
+          docs: ["The dbc virtual pool"];
+          writable: true;
+        },
+        {
+          name: "tokenQuoteAccount";
+          docs: ["The treasury token b account"];
+          writable: true;
+        },
+        {
+          name: "quoteVault";
+          writable: true;
+        },
+        {
+          name: "quoteMint";
+        },
+        {
+          name: "tokenBaseProgram";
+        },
+        {
+          name: "tokenQuoteProgram";
+        },
+        {
+          name: "dbcPoolAuthority";
+        },
+        {
+          name: "dbcProgram";
+          address: "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+        },
+        {
+          name: "dbcEventAuthority";
+        },
+        {
+          name: "eventAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ];
+              }
+            ];
+          };
+        },
+        {
+          name: "program";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "fundingByClaimDbcCreatorTradingFee";
+      discriminator: [255, 219, 222, 197, 46, 146, 167, 4];
+      accounts: [
+        {
+          name: "feeVault";
+          writable: true;
+        },
+        {
+          name: "config";
+        },
+        {
+          name: "pool";
+          writable: true;
+        },
+        {
+          name: "tokenAAccount";
+          writable: true;
+        },
+        {
+          name: "tokenBAccount";
+          docs: ["The token b account"];
+          writable: true;
+        },
+        {
+          name: "baseVault";
+          writable: true;
+        },
+        {
+          name: "quoteVault";
+          writable: true;
+        },
+        {
+          name: "baseMint";
+        },
+        {
+          name: "quoteMint";
+          relations: ["config"];
+        },
+        {
+          name: "tokenBaseProgram";
+        },
+        {
+          name: "tokenQuoteProgram";
+        },
+        {
+          name: "dbcPoolAuthority";
+        },
+        {
+          name: "dbcProgram";
+          address: "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+        },
+        {
+          name: "dbcEventAuthority";
+        },
+        {
+          name: "eventAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ];
+              }
+            ];
+          };
+        },
+        {
+          name: "program";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "fundingByClaimDbcPartnerSurplus";
+      discriminator: [146, 67, 241, 237, 23, 164, 213, 113];
+      accounts: [
+        {
+          name: "feeVault";
+          writable: true;
+        },
+        {
+          name: "config";
+        },
+        {
+          name: "pool";
+          docs: ["The dbc virtual pool"];
+          writable: true;
+        },
+        {
+          name: "tokenQuoteAccount";
+          docs: ["The token b account"];
+          writable: true;
+        },
+        {
+          name: "quoteVault";
+          writable: true;
+        },
+        {
+          name: "quoteMint";
+        },
+        {
+          name: "tokenBaseProgram";
+        },
+        {
+          name: "tokenQuoteProgram";
+        },
+        {
+          name: "dbcPoolAuthority";
+        },
+        {
+          name: "dbcProgram";
+          address: "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+        },
+        {
+          name: "dbcEventAuthority";
+        },
+        {
+          name: "eventAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ];
+              }
+            ];
+          };
+        },
+        {
+          name: "program";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "fundingByClaimDbcPartnerTradingFee";
+      discriminator: [0, 156, 54, 230, 218, 238, 81, 47];
+      accounts: [
+        {
+          name: "feeVault";
+          writable: true;
+        },
+        {
+          name: "config";
+        },
+        {
+          name: "pool";
+          writable: true;
+        },
+        {
+          name: "tokenAAccount";
+          writable: true;
+        },
+        {
+          name: "tokenBAccount";
+          docs: ["The treasury token b account"];
+          writable: true;
+        },
+        {
+          name: "baseVault";
+          writable: true;
+        },
+        {
+          name: "quoteVault";
+          writable: true;
+        },
+        {
+          name: "baseMint";
+        },
+        {
+          name: "quoteMint";
+          relations: ["config"];
+        },
+        {
+          name: "tokenBaseProgram";
+        },
+        {
+          name: "tokenQuoteProgram";
+        },
+        {
+          name: "dbcPoolAuthority";
+        },
+        {
+          name: "dbcProgram";
+          address: "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+        },
+        {
+          name: "dbcEventAuthority";
+        },
+        {
+          name: "eventAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ];
+              }
+            ];
+          };
+        },
+        {
+          name: "program";
+        }
+      ];
+      args: [];
     },
     {
       name: "initializeFeeVault";
@@ -440,6 +848,18 @@ export type DynamicFeeSharing = {
     {
       name: "feeVault";
       discriminator: [192, 178, 69, 232, 58, 149, 157, 132];
+    },
+    {
+      name: "pool";
+      discriminator: [241, 154, 109, 4, 17, 177, 109, 188];
+    },
+    {
+      name: "poolConfig";
+      discriminator: [26, 108, 14, 123, 116, 230, 129, 43];
+    },
+    {
+      name: "virtualPool";
+      discriminator: [213, 224, 5, 209, 98, 69, 119, 92];
     }
   ];
   events: [
@@ -491,9 +911,226 @@ export type DynamicFeeSharing = {
       code: 6006;
       name: "exceededUser";
       msg: "Exceeded number of users allowed";
+    },
+    {
+      code: 6007;
+      name: "invalidFeeVault";
+      msg: "Invalid fee vault";
+    },
+    {
+      code: 6008;
+      name: "invalidDammv2Pool";
+      msg: "Invalid dammv2 pool";
+    },
+    {
+      code: 6009;
+      name: "invalidDbcPool";
+      msg: "Invalid dammv2 pool";
     }
   ];
   types: [
+    {
+      name: "baseFeeConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "cliffFeeNumerator";
+            type: "u64";
+          },
+          {
+            name: "secondFactor";
+            type: "u64";
+          },
+          {
+            name: "thirdFactor";
+            type: "u64";
+          },
+          {
+            name: "firstFactor";
+            type: "u16";
+          },
+          {
+            name: "baseFeeMode";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 5];
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "baseFeeStruct";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "cliffFeeNumerator";
+            type: "u64";
+          },
+          {
+            name: "feeSchedulerMode";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 5];
+            };
+          },
+          {
+            name: "numberOfPeriod";
+            type: "u16";
+          },
+          {
+            name: "periodFrequency";
+            type: "u64";
+          },
+          {
+            name: "reductionFactor";
+            type: "u64";
+          },
+          {
+            name: "padding1";
+            type: "u64";
+          }
+        ];
+      };
+    },
+    {
+      name: "dynamicFeeConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "initialized";
+            type: "u8";
+          },
+          {
+            name: "padding";
+            type: {
+              array: ["u8", 7];
+            };
+          },
+          {
+            name: "maxVolatilityAccumulator";
+            type: "u32";
+          },
+          {
+            name: "variableFeeControl";
+            type: "u32";
+          },
+          {
+            name: "binStep";
+            type: "u16";
+          },
+          {
+            name: "filterPeriod";
+            type: "u16";
+          },
+          {
+            name: "decayPeriod";
+            type: "u16";
+          },
+          {
+            name: "reductionFactor";
+            type: "u16";
+          },
+          {
+            name: "padding2";
+            type: {
+              array: ["u8", 8];
+            };
+          },
+          {
+            name: "binStepU128";
+            type: "u128";
+          }
+        ];
+      };
+    },
+    {
+      name: "dynamicFeeStruct";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "initialized";
+            type: "u8";
+          },
+          {
+            name: "padding";
+            type: {
+              array: ["u8", 7];
+            };
+          },
+          {
+            name: "maxVolatilityAccumulator";
+            type: "u32";
+          },
+          {
+            name: "variableFeeControl";
+            type: "u32";
+          },
+          {
+            name: "binStep";
+            type: "u16";
+          },
+          {
+            name: "filterPeriod";
+            type: "u16";
+          },
+          {
+            name: "decayPeriod";
+            type: "u16";
+          },
+          {
+            name: "reductionFactor";
+            type: "u16";
+          },
+          {
+            name: "lastUpdateTimestamp";
+            type: "u64";
+          },
+          {
+            name: "binStepU128";
+            type: "u128";
+          },
+          {
+            name: "sqrtPriceReference";
+            type: "u128";
+          },
+          {
+            name: "volatilityAccumulator";
+            type: "u128";
+          },
+          {
+            name: "volatilityReference";
+            type: "u128";
+          }
+        ];
+      };
+    },
     {
       name: "evtClaimFee";
       type: {
@@ -524,6 +1161,14 @@ export type DynamicFeeSharing = {
         kind: "struct";
         fields: [
           {
+            name: "fundingType";
+            type: {
+              defined: {
+                name: "fundingType";
+              };
+            };
+          },
+          {
             name: "feeVault";
             type: "pubkey";
           },
@@ -532,11 +1177,7 @@ export type DynamicFeeSharing = {
             type: "pubkey";
           },
           {
-            name: "excludedTransferFeeAmount";
-            type: "u64";
-          },
-          {
-            name: "maxAmount";
+            name: "fundedAmount";
             type: "u64";
           },
           {
@@ -604,9 +1245,17 @@ export type DynamicFeeSharing = {
             type: "u8";
           },
           {
+            name: "feeVaultType";
+            type: "u8";
+          },
+          {
+            name: "feeVaultBump";
+            type: "u8";
+          },
+          {
             name: "padding0";
             type: {
-              array: ["u8", 15];
+              array: ["u8", 13];
             };
           },
           {
@@ -628,9 +1277,13 @@ export type DynamicFeeSharing = {
             type: "u128";
           },
           {
+            name: "base";
+            type: "pubkey";
+          },
+          {
             name: "padding";
             type: {
-              array: ["u128", 6];
+              array: ["u128", 4];
             };
           },
           {
@@ -645,6 +1298,35 @@ export type DynamicFeeSharing = {
                 5
               ];
             };
+          }
+        ];
+      };
+    },
+    {
+      name: "fundingType";
+      repr: {
+        kind: "rust";
+      };
+      type: {
+        kind: "enum";
+        variants: [
+          {
+            name: "direct";
+          },
+          {
+            name: "claimDammV2";
+          },
+          {
+            name: "claimDbcPartnerTradingFee";
+          },
+          {
+            name: "claimDbcCreatorTradingFee";
+          },
+          {
+            name: "claimDbcPartnerSurplus";
+          },
+          {
+            name: "claimDbcCreatorSurplus";
           }
         ];
       };
@@ -669,6 +1351,578 @@ export type DynamicFeeSharing = {
                 };
               };
             };
+          }
+        ];
+      };
+    },
+    {
+      name: "liquidityDistributionConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "sqrtPrice";
+            type: "u128";
+          },
+          {
+            name: "liquidity";
+            type: "u128";
+          }
+        ];
+      };
+    },
+    {
+      name: "lockedVestingConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "amountPerPeriod";
+            type: "u64";
+          },
+          {
+            name: "cliffDurationFromMigrationTime";
+            type: "u64";
+          },
+          {
+            name: "frequency";
+            type: "u64";
+          },
+          {
+            name: "numberOfPeriod";
+            type: "u64";
+          },
+          {
+            name: "cliffUnlockAmount";
+            type: "u64";
+          },
+          {
+            name: "padding";
+            type: "u64";
+          }
+        ];
+      };
+    },
+    {
+      name: "pool";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "poolFees";
+            type: {
+              defined: {
+                name: "poolFeesStruct";
+              };
+            };
+          },
+          {
+            name: "tokenAMint";
+            type: "pubkey";
+          },
+          {
+            name: "tokenBMint";
+            type: "pubkey";
+          },
+          {
+            name: "tokenAVault";
+            type: "pubkey";
+          },
+          {
+            name: "tokenBVault";
+            type: "pubkey";
+          },
+          {
+            name: "whitelistedVault";
+            type: "pubkey";
+          },
+          {
+            name: "partner";
+            type: "pubkey";
+          },
+          {
+            name: "liquidity";
+            type: "u128";
+          },
+          {
+            name: "padding";
+            type: "u128";
+          },
+          {
+            name: "protocolAFee";
+            type: "u64";
+          },
+          {
+            name: "protocolBFee";
+            type: "u64";
+          },
+          {
+            name: "partnerAFee";
+            type: "u64";
+          },
+          {
+            name: "partnerBFee";
+            type: "u64";
+          },
+          {
+            name: "sqrtMinPrice";
+            type: "u128";
+          },
+          {
+            name: "sqrtMaxPrice";
+            type: "u128";
+          },
+          {
+            name: "sqrtPrice";
+            type: "u128";
+          },
+          {
+            name: "activationPoint";
+            type: "u64";
+          },
+          {
+            name: "activationType";
+            type: "u8";
+          },
+          {
+            name: "poolStatus";
+            type: "u8";
+          },
+          {
+            name: "tokenAFlag";
+            type: "u8";
+          },
+          {
+            name: "tokenBFlag";
+            type: "u8";
+          },
+          {
+            name: "collectFeeMode";
+            type: "u8";
+          },
+          {
+            name: "poolType";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 2];
+            };
+          },
+          {
+            name: "feeAPerLiquidity";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "feeBPerLiquidity";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "permanentLockLiquidity";
+            type: "u128";
+          },
+          {
+            name: "metrics";
+            type: {
+              defined: {
+                name: "damm_v2::damm_v2::types::PoolMetrics";
+              };
+            };
+          },
+          {
+            name: "creator";
+            type: "pubkey";
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u64", 6];
+            };
+          },
+          {
+            name: "rewardInfos";
+            type: {
+              array: [
+                {
+                  defined: {
+                    name: "rewardInfo";
+                  };
+                },
+                2
+              ];
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "poolConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "quoteMint";
+            type: "pubkey";
+          },
+          {
+            name: "feeClaimer";
+            type: "pubkey";
+          },
+          {
+            name: "leftoverReceiver";
+            type: "pubkey";
+          },
+          {
+            name: "poolFees";
+            type: {
+              defined: {
+                name: "poolFeesConfig";
+              };
+            };
+          },
+          {
+            name: "collectFeeMode";
+            type: "u8";
+          },
+          {
+            name: "migrationOption";
+            type: "u8";
+          },
+          {
+            name: "activationType";
+            type: "u8";
+          },
+          {
+            name: "tokenDecimal";
+            type: "u8";
+          },
+          {
+            name: "version";
+            type: "u8";
+          },
+          {
+            name: "tokenType";
+            type: "u8";
+          },
+          {
+            name: "quoteTokenFlag";
+            type: "u8";
+          },
+          {
+            name: "partnerLockedLpPercentage";
+            type: "u8";
+          },
+          {
+            name: "partnerLpPercentage";
+            type: "u8";
+          },
+          {
+            name: "creatorLockedLpPercentage";
+            type: "u8";
+          },
+          {
+            name: "creatorLpPercentage";
+            type: "u8";
+          },
+          {
+            name: "migrationFeeOption";
+            type: "u8";
+          },
+          {
+            name: "fixedTokenSupplyFlag";
+            type: "u8";
+          },
+          {
+            name: "creatorTradingFeePercentage";
+            type: "u8";
+          },
+          {
+            name: "tokenUpdateAuthority";
+            type: "u8";
+          },
+          {
+            name: "migrationFeePercentage";
+            type: "u8";
+          },
+          {
+            name: "creatorMigrationFeePercentage";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 7];
+            };
+          },
+          {
+            name: "swapBaseAmount";
+            type: "u64";
+          },
+          {
+            name: "migrationQuoteThreshold";
+            type: "u64";
+          },
+          {
+            name: "migrationBaseThreshold";
+            type: "u64";
+          },
+          {
+            name: "migrationSqrtPrice";
+            type: "u128";
+          },
+          {
+            name: "lockedVestingConfig";
+            type: {
+              defined: {
+                name: "lockedVestingConfig";
+              };
+            };
+          },
+          {
+            name: "preMigrationTokenSupply";
+            type: "u64";
+          },
+          {
+            name: "postMigrationTokenSupply";
+            type: "u64";
+          },
+          {
+            name: "migratedCollectFeeMode";
+            type: "u8";
+          },
+          {
+            name: "migratedDynamicFee";
+            type: "u8";
+          },
+          {
+            name: "migratedPoolFeeBps";
+            type: "u16";
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u8", 12];
+            };
+          },
+          {
+            name: "padding2";
+            type: "u128";
+          },
+          {
+            name: "sqrtStartPrice";
+            type: "u128";
+          },
+          {
+            name: "curve";
+            type: {
+              array: [
+                {
+                  defined: {
+                    name: "liquidityDistributionConfig";
+                  };
+                },
+                20
+              ];
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "poolFeesConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "baseFee";
+            type: {
+              defined: {
+                name: "baseFeeConfig";
+              };
+            };
+          },
+          {
+            name: "dynamicFee";
+            type: {
+              defined: {
+                name: "dynamicFeeConfig";
+              };
+            };
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u64", 5];
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u8", 6];
+            };
+          },
+          {
+            name: "protocolFeePercent";
+            type: "u8";
+          },
+          {
+            name: "referralFeePercent";
+            type: "u8";
+          }
+        ];
+      };
+    },
+    {
+      name: "poolFeesStruct";
+      docs: [
+        "Information regarding fee charges",
+        "trading_fee = amount * trade_fee_numerator / denominator",
+        "protocol_fee = trading_fee * protocol_fee_percentage / 100",
+        "referral_fee = protocol_fee * referral_percentage / 100",
+        "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+      ];
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "baseFee";
+            type: {
+              defined: {
+                name: "baseFeeStruct";
+              };
+            };
+          },
+          {
+            name: "protocolFeePercent";
+            type: "u8";
+          },
+          {
+            name: "partnerFeePercent";
+            type: "u8";
+          },
+          {
+            name: "referralFeePercent";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 5];
+            };
+          },
+          {
+            name: "dynamicFee";
+            type: {
+              defined: {
+                name: "dynamicFeeStruct";
+              };
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u64", 2];
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "rewardInfo";
+      docs: ["Stores the state relevant for tracking liquidity mining rewards"];
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "initialized";
+            type: "u8";
+          },
+          {
+            name: "rewardTokenFlag";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 6];
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u8", 8];
+            };
+          },
+          {
+            name: "mint";
+            type: "pubkey";
+          },
+          {
+            name: "vault";
+            type: "pubkey";
+          },
+          {
+            name: "funder";
+            type: "pubkey";
+          },
+          {
+            name: "rewardDuration";
+            type: "u64";
+          },
+          {
+            name: "rewardDurationEnd";
+            type: "u64";
+          },
+          {
+            name: "rewardRate";
+            type: "u128";
+          },
+          {
+            name: "rewardPerTokenStored";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "lastUpdateTime";
+            type: "u64";
+          },
+          {
+            name: "cumulativeSecondsWithEmptyLiquidityReward";
+            type: "u64";
           }
         ];
       };
@@ -725,6 +1979,242 @@ export type DynamicFeeSharing = {
           {
             name: "share";
             type: "u32";
+          }
+        ];
+      };
+    },
+    {
+      name: "virtualPool";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "volatilityTracker";
+            type: {
+              defined: {
+                name: "volatilityTracker";
+              };
+            };
+          },
+          {
+            name: "config";
+            type: "pubkey";
+          },
+          {
+            name: "creator";
+            type: "pubkey";
+          },
+          {
+            name: "baseMint";
+            type: "pubkey";
+          },
+          {
+            name: "baseVault";
+            type: "pubkey";
+          },
+          {
+            name: "quoteVault";
+            type: "pubkey";
+          },
+          {
+            name: "baseReserve";
+            type: "u64";
+          },
+          {
+            name: "quoteReserve";
+            type: "u64";
+          },
+          {
+            name: "protocolBaseFee";
+            type: "u64";
+          },
+          {
+            name: "protocolQuoteFee";
+            type: "u64";
+          },
+          {
+            name: "partnerBaseFee";
+            type: "u64";
+          },
+          {
+            name: "partnerQuoteFee";
+            type: "u64";
+          },
+          {
+            name: "sqrtPrice";
+            type: "u128";
+          },
+          {
+            name: "activationPoint";
+            type: "u64";
+          },
+          {
+            name: "poolType";
+            type: "u8";
+          },
+          {
+            name: "isMigrated";
+            type: "u8";
+          },
+          {
+            name: "isPartnerWithdrawSurplus";
+            type: "u8";
+          },
+          {
+            name: "isProtocolWithdrawSurplus";
+            type: "u8";
+          },
+          {
+            name: "migrationProgress";
+            type: "u8";
+          },
+          {
+            name: "isWithdrawLeftover";
+            type: "u8";
+          },
+          {
+            name: "isCreatorWithdrawSurplus";
+            type: "u8";
+          },
+          {
+            name: "migrationFeeWithdrawStatus";
+            type: "u8";
+          },
+          {
+            name: "metrics";
+            type: {
+              defined: {
+                name: "dynamic_bonding_curve::dynamic_bonding_curve::types::PoolMetrics";
+              };
+            };
+          },
+          {
+            name: "finishCurveTimestamp";
+            type: "u64";
+          },
+          {
+            name: "creatorBaseFee";
+            type: "u64";
+          },
+          {
+            name: "creatorQuoteFee";
+            type: "u64";
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u64", 7];
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "volatilityTracker";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "lastUpdateTimestamp";
+            type: "u64";
+          },
+          {
+            name: "padding";
+            type: {
+              array: ["u8", 8];
+            };
+          },
+          {
+            name: "sqrtPriceReference";
+            type: "u128";
+          },
+          {
+            name: "volatilityAccumulator";
+            type: "u128";
+          },
+          {
+            name: "volatilityReference";
+            type: "u128";
+          }
+        ];
+      };
+    },
+    {
+      name: "damm_v2::damm_v2::types::PoolMetrics";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "totalLpAFee";
+            type: "u128";
+          },
+          {
+            name: "totalLpBFee";
+            type: "u128";
+          },
+          {
+            name: "totalProtocolAFee";
+            type: "u64";
+          },
+          {
+            name: "totalProtocolBFee";
+            type: "u64";
+          },
+          {
+            name: "totalPartnerAFee";
+            type: "u64";
+          },
+          {
+            name: "totalPartnerBFee";
+            type: "u64";
+          },
+          {
+            name: "totalPosition";
+            type: "u64";
+          },
+          {
+            name: "padding";
+            type: "u64";
+          }
+        ];
+      };
+    },
+    {
+      name: "dynamic_bonding_curve::dynamic_bonding_curve::types::PoolMetrics";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "totalProtocolBaseFee";
+            type: "u64";
+          },
+          {
+            name: "totalProtocolQuoteFee";
+            type: "u64";
+          },
+          {
+            name: "totalTradingBaseFee";
+            type: "u64";
+          },
+          {
+            name: "totalTradingQuoteFee";
+            type: "u64";
           }
         ];
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,41 @@ export type FundFeeVaultParams = {
   funder: PublicKey;
 };
 
+export type FundByDammV2ClaimFeeParams = {
+  owner: PublicKey;
+  feeVault: PublicKey;
+  tokenVault: PublicKey;
+  dammV2Pool: PublicKey;
+  position: PublicKey;
+  positionNftAccount: PublicKey;
+};
+
+export type FundByDbcClaimCreatorTradingFeeParams = {
+  creator: PublicKey;
+  feeVault: PublicKey;
+  tokenVault: PublicKey;
+  dbcConfig: PublicKey;
+  dbcPool: PublicKey;
+};
+
+export type FundByDbcClaimPartnerTradingFeeParams = {
+  feeClaimer: PublicKey;
+  feeVault: PublicKey;
+  tokenVault: PublicKey;
+  dbcConfig: PublicKey;
+  dbcPool: PublicKey;
+};
+
+export type FundByDbcClaimCreatorSurplusParams = {
+  feeVault: PublicKey;
+  tokenVault: PublicKey;
+  dbcConfig: PublicKey;
+  dbcPool: PublicKey;
+};
+
+export type FundByDbcClaimPartnerSurplusParams =
+  FundByDbcClaimCreatorSurplusParams;
+
 export type ClaimUserFeeParams = {
   feeVault: PublicKey;
   user: PublicKey;


### PR DESCRIPTION
Funding Fee Endpoints

- fundByDammV2ClaimFee
- fundByDbcCreatorSurplus
- fundByDbcPartnerSurplus
- fundByDbcCreatorTradingFee
- fundByDbcPartnerTradingFee

NOTE:
- DBC `feeClaimer` needs to be a `feeVaultPda`
- DBC `creator` needs to be the `feeVaultPda`
- DAMM v2 requires the NFT position to `setAuthority` to `feeVaultPda`